### PR TITLE
Lower checkout version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout PR Head
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         token: ${{ inputs.github_token }}
         ref: refs/pull/${{ inputs.pull_number }}/head


### PR DESCRIPTION
## Update: Pin actions/checkout to v4.0.0

Lower the pinned version of `actions/checkout` used by our composite action to ensure stable behavior and compatibility with our workflows. This change affects only the checkout step that retrieves the PR head in `action.yml`.

### Key changes
- Pin `actions/checkout` to commit `3df4ab11…` (v4.0.0) instead of `11bd7190…` (v4.2.2)
- Continue using a SHA-pinned reference for reproducibility

### Impact
- No functional changes expected to the action logic; only the underlying checkout action version is adjusted
- Reduces risk of regressions from newer `actions/checkout` releases in our pipeline

Related: augmentcode/augment-agent#2

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*