### PR TITLE
Add icon/color

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "AI-powered PR Descriptions"
 author: "Augment Code"
 branding:
   icon: "zap"
-  color: "purple""
+  color: "purple"
 
 inputs:
   augment_session_auth:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: "Augment Describe PR"
 description: "AI-powered PR Descriptions"
 author: "Augment Code"
+branding:
+  icon: "zap"
+  color: "purple""
 
 inputs:
   augment_session_auth:


### PR DESCRIPTION
Add GitHub Marketplace icon and color metadata

- Set icon: "zap" to display a lightning bolt in the Marketplace
- Set color: "purple" to style the action’s badge/listing