### PR TITLE
Add support for rules and MCP Configs to be piped to augment-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Each example includes a complete workflow file that you can copy to your `.githu
 | `repo_name`            | The full name (owner/repo) of the repository          | Yes      | `${{ github.repository }}`                          |
 | `custom_guidelines`    | Custom guidelines for PR descriptions (optional)      | No       | See [Custom Guidelines](#custom-guidelines) section |
 | `model`                | Optional model to use for generation                  | No       | e.g. `sonnet4`, from `auggie --list-models`         |
+| `rules`                | JSON array of rules file paths forwarded to agent     | No       | `[".augment/rules.md"]`                             |
+| `mcp_configs`          | JSON array of MCP config paths forwarded to agent     | No       | `[".augment/mcp.md"]`                               |
 
 ## How It Works
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,12 @@ inputs:
   model:
     description: "Optional model to use for generation. Passed directly to augment-agent."
     required: false
+  rules:
+    description: "Optional JSON array of rules file paths forwarded to augment-agent."
+    required: false
+  mcp_configs:
+    description: "Optional JSON array of MCP config file paths forwarded to augment-agent."
+    required: false
 
 runs:
   using: "composite"
@@ -56,3 +62,5 @@ runs:
         repo_name: ${{ inputs.repo_name }}
         custom_context: ${{ steps.custom_context.outputs.context }}
         model: ${{ inputs.model }}
+        rules: ${{ inputs.rules }}
+        mcp_configs: ${{ inputs.mcp_configs }}


### PR DESCRIPTION
Add optional inputs to forward rules and MCP configs to augment-agent

- Document the `rules` and `mcp_configs` inputs so workflows can surface curated context files
- Pass the new inputs through the composite action so augment-agent receives them during execution

This lets repositories share guardrails and MCP configuration with the agent without custom scripting.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*