### PR TITLE
Add optional fetch_depth parameter for shallow clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Each example includes a complete workflow file that you can copy to your `.githu
 | `model`                | Optional model to use for generation                  | No       | e.g. `sonnet4`, from `auggie --list-models`         |
 | `rules`                | JSON array of rules file paths forwarded to agent     | No       | `[".augment/rules.md"]`                             |
 | `mcp_configs`          | JSON array of MCP config paths forwarded to agent     | No       | `[".augment/mcp.md"]`                               |
+| `fetch_depth`          | Optional fetch depth for git checkout (default: 0)   | No       | `10` for shallow clones, `0` for full history       |
 
 ## How It Works
 
@@ -91,6 +92,20 @@ Each example includes a complete workflow file that you can copy to your `.githu
 3. **Template Rendering**: Uses Nunjucks templates to create a structured instruction for the AI
 4. **AI Processing**: Calls the Augment Agent to analyze the changes and generate a description
 5. **PR Update**: The Augment Agent updates the PR description with the generated content
+
+## Performance Optimization
+
+For large repositories with long history, you can use the `fetch_depth` parameter to speed up checkouts by limiting the git history fetched:
+
+```yaml
+- name: Generate PR Description
+  uses: augmentcode/describe-pr@v0
+  with:
+    # ... other inputs ...
+    fetch_depth: 50  # Only fetch last 50 commits
+```
+
+This can significantly reduce checkout time for repositories with extensive history while still providing enough context for PR description generation.
 
 ## Custom Guidelines
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Each example includes a complete workflow file that you can copy to your `.githu
 | `model`                | Optional model to use for generation                  | No       | e.g. `sonnet4`, from `auggie --list-models`         |
 | `rules`                | JSON array of rules file paths forwarded to agent     | No       | `[".augment/rules.md"]`                             |
 | `mcp_configs`          | JSON array of MCP config paths forwarded to agent     | No       | `[".augment/mcp.md"]`                               |
-| `fetch_depth`          | Optional fetch depth for git checkout (default: 0)   | No       | `10` for shallow clones, `0` for full history       |
+| `fetch_depth`          | Optional fetch depth for git checkout (default: 0)    | No       | `10` for shallow clones, `0` for full history       |
 
 ## How It Works
 
@@ -102,7 +102,7 @@ For large repositories with long history, you can use the `fetch_depth` paramete
   uses: augmentcode/describe-pr@v0
   with:
     # ... other inputs ...
-    fetch_depth: 50  # Only fetch last 50 commits
+    fetch_depth: 50 # Only fetch last 50 commits
 ```
 
 This can significantly reduce checkout time for repositories with extensive history while still providing enough context for PR description generation.

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
   mcp_configs:
     description: "Optional JSON array of MCP config file paths forwarded to augment-agent."
     required: false
+  fetch_depth:
+    description: "Optional fetch depth for git checkout. Default is 0 (full history). Set to a positive number for shallow clones."
+    required: false
+    default: "0"
 
 runs:
   using: "composite"
@@ -39,7 +43,7 @@ runs:
       with:
         token: ${{ inputs.github_token }}
         ref: refs/pull/${{ inputs.pull_number }}/head
-        fetch-depth: 0
+        fetch-depth: ${{ inputs.fetch_depth }}
 
     - name: Prepare Custom Context
       id: custom_context


### PR DESCRIPTION
Add configurable git checkout depth for performance optimization

Introduces an optional `fetch_depth` parameter that allows users to control the number of commits fetched during checkout, enabling shallow clones for faster performance on large repositories.

## Key Changes

- Add `fetch_depth` input parameter to the action with a default value of `0` (full history)
- Update checkout step to use the configurable depth instead of hardcoded value
- Document the new parameter in the README inputs table
- Add "Performance Optimization" section with usage examples

## Benefits

- **Faster checkouts**: Shallow clones can significantly reduce checkout time for repositories with extensive history
- **Flexible configuration**: Users can choose the optimal depth based on their needs
- **Backward compatible**: Default behavior remains unchanged (full history)

## Usage Example

```yaml
- name: Generate PR Description
  uses: augmentcode/describe-pr@v0
  with:
    augment_session_auth: ${{ secrets.AUGMENT_SESSION_AUTH }}
    github_token: ${{ secrets.GITHUB_TOKEN }}
    pull_number: ${{ github.event.pull_request.number }}
    repo_name: ${{ github.repository }}
    fetch_depth: 50  # Only fetch last 50 commits for faster checkout
```

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*